### PR TITLE
Add enums for bank account types and record categories, update schemas

### DIFF
--- a/actions/onboard.ts
+++ b/actions/onboard.ts
@@ -52,9 +52,9 @@ export async function createFirstAccountAndRecord(
   await db.insert(records).values({
     userId,
     amount: String(balance),
-    status: "Cleared",
+    status: "Completed",
     account: account.id,
-    category: "Initial balance",
+    category: "Transfer",
     type: "Income",
   });
 }

--- a/components/account/account-card.tsx
+++ b/components/account/account-card.tsx
@@ -43,7 +43,7 @@ export function AccountCard({ account }: AccountCardProps) {
     defaultValues: {
       userId: account.userId,
       title: account.title,
-      type: account.type as "Checking" | "Saving" | undefined,
+      type: account.type,
       balance: parseFloat(account.balance),
       color: account.color,
       icon: account.icon,

--- a/components/records/create-record.tsx
+++ b/components/records/create-record.tsx
@@ -35,8 +35,8 @@ export function CreateRecord({ accounts }: CreateRecordProps) {
     defaultValues: {
       userId: accounts[0].userId,
       amount: 0,
-      category: "Transportation",
-      status: "Cleared",
+      category: "Other",
+      status: "Completed",
       type: "Income",
       account: accounts[0].id,
     },

--- a/drizzle/0015_simple_dormammu.sql
+++ b/drizzle/0015_simple_dormammu.sql
@@ -1,0 +1,14 @@
+CREATE TYPE "public"."bank_account_type" AS ENUM('Cash', 'Checking', 'Savings', 'Credit', 'Debit', 'Investment', 'Loan', 'Other');--> statement-breakpoint
+CREATE TYPE "public"."record_category" AS ENUM('Salary', 'Bonus', 'Interest', 'Dividend', 'Gift', 'Investment', 'Rent', 'Utilities', 'Groceries', 'Dining', 'Transportation', 'Entertainment', 'Health', 'Insurance', 'Education', 'Charity', 'Transfer', 'Other');--> statement-breakpoint
+CREATE TYPE "public"."record_status" AS ENUM('Pending', 'Completed', 'Failed');--> statement-breakpoint
+CREATE TYPE "public"."record_type" AS ENUM('Income', 'Expense', 'Transfer');--> statement-breakpoint
+ALTER TABLE "bank_account" ALTER COLUMN "type" SET DATA TYPE bank_account_type;--> statement-breakpoint
+ALTER TABLE "records" ALTER COLUMN "category" SET DATA TYPE record_category;--> statement-breakpoint
+ALTER TABLE "records" ALTER COLUMN "type" SET DATA TYPE record_type;--> statement-breakpoint
+ALTER TABLE "records" ALTER COLUMN "status" SET DATA TYPE record_status;--> statement-breakpoint
+ALTER TABLE "preference" ADD COLUMN "defaultAccount" text;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "preference" ADD CONSTRAINT "preference_defaultAccount_bank_account_id_fk" FOREIGN KEY ("defaultAccount") REFERENCES "public"."bank_account"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/db/schema.ts
+++ b/drizzle/db/schema.ts
@@ -1,4 +1,10 @@
-import { icons } from "@/lib/utils";
+import {
+  bankAccountTypes,
+  icons,
+  recordCategories,
+  recordStatuses,
+  recordTypes,
+} from "@/lib/utils";
 import {
   boolean,
   decimal,
@@ -95,10 +101,11 @@ export const preferences = pgTable("preference", {
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),
   currency: text("currency").notNull(),
-  // defaultAccount: text("defaultAccount").references(() => accounts.id),
+  defaultAccount: text("defaultAccount").references(() => bankAccounts.id),
 });
 
 export const bankAccountIcon = pgEnum("bank_account_icon", icons);
+export const bankAccountType = pgEnum("bank_account_type", bankAccountTypes);
 
 export const bankAccounts = pgTable("bank_account", {
   id: text("id")
@@ -112,11 +119,15 @@ export const bankAccounts = pgTable("bank_account", {
   icon: bankAccountIcon("icon").notNull(),
   color: text("color").notNull(),
   balance: decimal({ precision: 10, scale: 2 }).notNull(),
-  type: text("type").notNull(),
+  type: bankAccountType("type").notNull(),
 });
 
 const selectBankAccountSchema = createSelectSchema(bankAccounts);
 export type SelectBankAccount = z.infer<typeof selectBankAccountSchema>;
+
+export const recordType = pgEnum("record_type", recordTypes);
+export const recordCategory = pgEnum("record_category", recordCategories);
+export const recordStatus = pgEnum("record_status", recordStatuses);
 
 export const records = pgTable("records", {
   userId: text("userId")
@@ -129,9 +140,9 @@ export const records = pgTable("records", {
     .notNull()
     .references(() => bankAccounts.id, { onDelete: "cascade" }),
   amount: decimal({ precision: 10, scale: 2 }).notNull(),
-  category: text("category").notNull(),
-  type: text("type").notNull(),
-  status: text("status").notNull(),
+  category: recordCategory("category").notNull(),
+  type: recordType("type").notNull(),
+  status: recordStatus("status").notNull(),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,653 @@
+{
+  "id": "7697659b-2c7e-4006-8592-bd1e5c9ddc3c",
+  "prevId": "58ffffca-d5c7-4305-ac07-5aed2d632413",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticator": {
+      "name": "authenticator",
+      "schema": "",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticator_userId_user_id_fk": {
+          "name": "authenticator_userId_user_id_fk",
+          "tableFrom": "authenticator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticator_userId_credentialID_pk": {
+          "name": "authenticator_userId_credentialID_pk",
+          "columns": [
+            "userId",
+            "credentialID"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "authenticator_credentialID_unique": {
+          "name": "authenticator_credentialID_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialID"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bank_account": {
+      "name": "bank_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "bank_account_icon",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "bank_account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_account_userId_user_id_fk": {
+          "name": "bank_account_userId_user_id_fk",
+          "tableFrom": "bank_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preference": {
+      "name": "preference",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defaultAccount": {
+          "name": "defaultAccount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "preference_userId_user_id_fk": {
+          "name": "preference_userId_user_id_fk",
+          "tableFrom": "preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "preference_defaultAccount_bank_account_id_fk": {
+          "name": "preference_defaultAccount_bank_account_id_fk",
+          "tableFrom": "preference",
+          "tableTo": "bank_account",
+          "columnsFrom": [
+            "defaultAccount"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.records": {
+      "name": "records",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account": {
+          "name": "bank_account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "record_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "record_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "records_userId_user_id_fk": {
+          "name": "records_userId_user_id_fk",
+          "tableFrom": "records",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "records_bank_account_bank_account_id_fk": {
+          "name": "records_bank_account_bank_account_id_fk",
+          "tableFrom": "records",
+          "tableTo": "bank_account",
+          "columnsFrom": [
+            "bank_account"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "name": "verificationToken_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bank_account_icon": {
+      "name": "bank_account_icon",
+      "schema": "public",
+      "values": [
+        "Wallet",
+        "CreditCard",
+        "PiggyBank",
+        "DollarSign",
+        "Banknote",
+        "Coins",
+        "Receipt",
+        "Landmark",
+        "Building",
+        "CircleDollarSign"
+      ]
+    },
+    "public.bank_account_type": {
+      "name": "bank_account_type",
+      "schema": "public",
+      "values": [
+        "Cash",
+        "Checking",
+        "Savings",
+        "Credit",
+        "Debit",
+        "Investment",
+        "Loan",
+        "Other"
+      ]
+    },
+    "public.record_category": {
+      "name": "record_category",
+      "schema": "public",
+      "values": [
+        "Salary",
+        "Bonus",
+        "Interest",
+        "Dividend",
+        "Gift",
+        "Investment",
+        "Rent",
+        "Utilities",
+        "Groceries",
+        "Dining",
+        "Transportation",
+        "Entertainment",
+        "Health",
+        "Insurance",
+        "Education",
+        "Charity",
+        "Transfer",
+        "Other"
+      ]
+    },
+    "public.record_status": {
+      "name": "record_status",
+      "schema": "public",
+      "values": [
+        "Pending",
+        "Completed",
+        "Failed"
+      ]
+    },
+    "public.record_type": {
+      "name": "record_type",
+      "schema": "public",
+      "values": [
+        "Income",
+        "Expense",
+        "Transfer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1735149396452,
       "tag": "0014_melodic_echo",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1735241516834,
+      "tag": "0015_simple_dormammu",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/forms/account.ts
+++ b/lib/forms/account.ts
@@ -1,4 +1,5 @@
 import { icons } from "@/lib/utils";
+import { bankAccountTypes } from "@/lib/utils";
 import { z } from "zod";
 
 export const accountSchema = z.object({
@@ -7,7 +8,7 @@ export const accountSchema = z.object({
   color: z
     .string()
     .regex(/^#(?:[0-9a-fA-F]{3}){1,2}$/, "Invalid hex color code"),
-  type: z.enum(["Checking", "Saving"], { message: "Invalid account type" }),
+  type: z.enum(bankAccountTypes, { message: "Invalid account type" }),
   icon: z.enum(icons, { message: "Invalid icon" }),
   description: z.string().min(1, "Enter at least 1 character"),
   balance: z.number().default(0),

--- a/lib/forms/record.ts
+++ b/lib/forms/record.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
+import { recordCategories, recordStatuses, recordTypes } from "../utils";
 
 export const recordSchema = z.object({
   id: z.string().optional(),
   userId: z.string(),
   amount: z.number(),
-  type: z.enum(["Income", "Expense", "Transfer"]),
+  type: z.enum(recordTypes),
   account: z.string(),
-  category: z.string(),
-  status: z.enum(["Cleared", "Pending"]),
-  created: z.date().optional(),
-  updated: z.date().optional(),
+  category: z.enum(recordCategories),
+  status: z.enum(recordStatuses),
+  created: z.date(),
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -17,3 +17,39 @@ export const icons = [
   "Building",
   "CircleDollarSign",
 ] as const; // Add 'as const' to create a readonly tuple
+
+export const bankAccountTypes = [
+  "Cash",
+  "Checking",
+  "Savings",
+  "Credit",
+  "Debit",
+  "Investment",
+  "Loan",
+  "Other",
+] as const;
+
+export const recordTypes = ["Income", "Expense", "Transfer"] as const;
+
+export const recordCategories = [
+  "Salary",
+  "Bonus",
+  "Interest",
+  "Dividend",
+  "Gift",
+  "Investment",
+  "Rent",
+  "Utilities",
+  "Groceries",
+  "Dining",
+  "Transportation",
+  "Entertainment",
+  "Health",
+  "Insurance",
+  "Education",
+  "Charity",
+  "Transfer",
+  "Other",
+] as const;
+
+export const recordStatuses = ["Pending", "Completed", "Failed"] as const;


### PR DESCRIPTION
Closes: #57 

Introduce new enums for bank account types and record categories in the database. Update the corresponding schemas and default values to align with these changes.